### PR TITLE
Starting from Atom v1.13.0, the contents of atom-text-editor elements…

### DIFF
--- a/styles/highlight-selected.less
+++ b/styles/highlight-selected.less
@@ -3,7 +3,7 @@
 // See https://github.com/atom/atom-dark-ui/blob/master/styles/ui-variables.less
 // for a full listing of what's available.
 @import "ui-variables";
-:host, atom-text-editor, atom-text-editor::shadow {
+atom-text-editor {
   atom-text-editor .highlight.highlight-selected .region {
     position: absolute;
     pointer-events: none;


### PR DESCRIPTION
… are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax