### PR TITLE
Fix bug where selecting symbols gives error

### DIFF
--- a/lib/highlighted-area-view.coffee
+++ b/lib/highlighted-area-view.coffee
@@ -98,9 +98,9 @@ class HighlightedAreaView
   highLightOneSelection: (text, i) ->
     editor = @getActiveEditor()
     regex = new RegExp("\\S*\\w*\\b", 'gi')
+    return unless result?
     result = regex.exec(text)
 
-    return unless result?
     return if result[0].length < atom.config.get(
       'highlight-selected.minimumLength') or
               result.index isnt 0 or


### PR DESCRIPTION
Previously, selecting symbols instead of words would give a TypeError. I hope this is the correct way to fix it.